### PR TITLE
Add missing period in Pytorch Module snippet

### DIFF
--- a/snippets/pytorch.json
+++ b/snippets/pytorch.json
@@ -43,7 +43,7 @@
             "class ${1:MyModule}(nn.Module):",            
             "\t\"\"\"Some Information about ${1:MyModule}\"\"\"",
             "\tdef __init__(self):",
-            "\t\tsuper(${1:MyModule}, self)__init__()",
+            "\t\tsuper(${1:MyModule}, self).__init__()",
             "",
             "\tdef forward(self, x):",
             "",


### PR DESCRIPTION
Was `super(Model, self)__init__()` (missing a period between `super()` and `__init__()`)