### PR TITLE
bug-fix: add ) for pytorch:train

### DIFF
--- a/snippets/pytorch.json
+++ b/snippets/pytorch.json
@@ -165,7 +165,7 @@
             "",
             "\t\trunning_loss += loss.item()",
             "",
-            "\tprint('Loss: {}'.format(running_loss)",
+            "\tprint('Loss: {}'.format(running_loss))",
             "",
             "print('Finished Training')"
         ]


### PR DESCRIPTION
The `pytorch.train` code is lack of a right bracket. This pull will fix it.